### PR TITLE
Add collateral to build ARM64 CI emulator tarball

### DIFF
--- a/src/arm/build-emulator
+++ b/src/arm/build-emulator
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# This script creates a tarball that contains a QEMU-based emulator for an ARM64
+# board with ARM TrustZone support. Additionally, the tarball contains a Linux
+# kernel, a root filesystem, and firmware images with ATF, OP-TEE, and UEFI. The
+# resulting contents are included in the SDK's full Docker container images to
+# run the SDK's test suite for Open Enclave on OP-TEE on ARM TrustZone.
+
+# NOTE: The resulting QEMU binary must run on Ubuntu 16.04 and on Ubuntu 18.04.
+#       Thus, this script must be run on Ubuntu 16.04 to ensure that it
+#       generates binaries compatible with both versions.
+
+sudo apt update && sudo apt install -y android-tools-adb                       \
+    android-tools-fastboot autoconf automake bc bison build-essential ccache   \
+    cgdb cscope curl device-tree-compiler expect flex ftp-upload gdb-multiarch \
+    gdisk iasl libattr1-dev libc6 libcap-dev libfdt-dev libftdi-dev            \
+    libglib2.0-dev libhidapi-dev libncurses5-dev libpixman-1-dev libssl-dev    \
+    libstdc++6 libtool libz1 make mtools netcat python-crypto                  \
+    python-pyelftools python-serial python-wand python3-pyelftools repo unzip  \
+    uuid-dev xdg-utils xterm xz-utils zlib1g-dev
+
+ROOT_DIR=$PWD
+
+mkdir arm64-tz-emulator
+pushd arm64-tz-emulator
+
+repo init -u https://github.com/ms-iot/optee_manifest -m oe_qemu_v8.xml -b oe-3.6.0
+repo sync -j$(nproc)
+
+pushd arm-trusted-firmware
+git apply $ROOT_DIR/patches/arm-trusted-firmware.patch
+popd
+
+pushd build
+git apply $ROOT_DIR/patches/build.patch
+cp $ROOT_DIR/patches/users ./br-ext/configs/
+popd
+
+pushd optee_os
+git apply $ROOT_DIR/patches/optee_os.patch
+popd
+
+pushd qemu
+git apply $ROOT_DIR/patches/qemu.patch
+popd
+
+pushd build
+make toolchains -j2
+make run -j$(nproc)
+popd
+
+mkdir pack
+
+cp out/bin/* pack/
+cp qemu/aarch64-softmmu/qemu-system-aarch64 pack/
+cp qemu/pc-bios/efi-virtio.rom pack/
+
+pushd pack
+GZIP=-9 tar cvzf ../OE-CI-emulator-armtz-aarch64.tar.gz *
+popd

--- a/src/arm/patches/arm-trusted-firmware.patch
+++ b/src/arm/patches/arm-trusted-firmware.patch
@@ -1,0 +1,13 @@
+diff --git a/include/plat/arm/common/arm_def.h b/include/plat/arm/common/arm_def.h
+index 4e9c70aa1..e3fee9b26 100644
+--- a/include/plat/arm/common/arm_def.h
++++ b/include/plat/arm/common/arm_def.h
+@@ -69,7 +69,7 @@
+  *   - SCP TZC DRAM: If present, DRAM reserved for SCP use
+  *   - AP TZC DRAM: The remaining TZC secured DRAM reserved for AP use
+  */
+-#define ARM_TZC_DRAM1_SIZE		UL(0x01000000)
++#define ARM_TZC_DRAM1_SIZE		UL(0x02000000)
+ 
+ #define ARM_SCP_TZC_DRAM1_BASE		(ARM_DRAM1_BASE +		\
+ 					 ARM_DRAM1_SIZE -		\

--- a/src/arm/patches/build.patch
+++ b/src/arm/patches/build.patch
@@ -1,0 +1,44 @@
+diff --git a/common.mk b/common.mk
+index 8aac6a7..0c579db 100644
+--- a/common.mk
++++ b/common.mk
+@@ -243,6 +243,10 @@ endif
+ 	@echo "BR2_PACKAGE_OPENSSL=y" >> ../out-br/extra.conf
+ 	@echo "BR2_PACKAGE_LIBOPENSSL=y" >> ../out-br/extra.conf
+ 	@echo "BR2_PACKAGE_MMC_UTILS=y" >> ../out-br/extra.conf
++	@echo "BR2_PACKAGE_CMAKE_CTEST=y" >> ../out-br/extra.conf
++	@echo "BR2_TARGET_ENABLE_ROOT_LOGIN=y" >> ../out-br/extra.conf
++	@echo "BR2_PACKAGE_DROPBEAR=y" >> ../out-br/extra.conf
++	@echo "BR2_ROOTFS_USERS_TABLES=\"../build/br-ext/configs/users\"" >> ../out-br/extra.conf
+ 	@(cd .. && python build/br-ext/scripts/make_def_config.py \
+ 		--br buildroot --out out-br --br-ext build/br-ext \
+ 		--top-dir "$(ROOT)" \
+diff --git a/qemu_v8.mk b/qemu_v8.mk
+index bf86ea2..9693f99 100644
+--- a/qemu_v8.mk
++++ b/qemu_v8.mk
+@@ -161,24 +161,6 @@ QEMU_SMP ?= 2
+ .PHONY: run-only
+ run-only:
+ 	ln -sf $(ROOT)/out-br/images/rootfs.cpio.gz $(BINARIES_PATH)/
+-	$(call check-terminal)
+-	$(call run-help)
+-	$(call launch-terminal,54320,"Normal World")
+-	$(call launch-terminal,54321,"Secure World")
+-	$(call wait-for-ports,54320,54321)
+-	cd $(BINARIES_PATH) && $(QEMU_PATH)/aarch64-softmmu/qemu-system-aarch64 \
+-		-nographic \
+-		-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+-		-smp $(QEMU_SMP) \
+-		-s -S -machine virt,secure=on -cpu cortex-a57 \
+-		-d unimp -semihosting-config enable,target=native \
+-		-m 1057 \
+-		-bios bl1.bin \
+-		-initrd rootfs.cpio.gz \
+-		-kernel Image -no-acpi \
+-		-append 'console=ttyAMA0,38400 keep_bootcon root=/dev/vda2' \
+-		-virtfs local,id=sh0,path=$(HOME),security_model=passthrough,readonly,mount_tag=sh0 \
+-		$(QEMU_EXTRA_ARGS)
+ 
+ ifneq ($(filter check,$(MAKECMDGOALS)),)
+ CHECK_DEPS := all

--- a/src/arm/patches/optee_os.patch
+++ b/src/arm/patches/optee_os.patch
@@ -1,0 +1,63 @@
+diff --git a/core/arch/arm/include/mm/pgt_cache.h b/core/arch/arm/include/mm/pgt_cache.h
+index 99b9058..bbb41eb 100644
+--- a/core/arch/arm/include/mm/pgt_cache.h
++++ b/core/arch/arm/include/mm/pgt_cache.h
+@@ -38,9 +38,9 @@ struct pgt {
+  * Reserve 2 page tables per thread, but at least 4 page tables in total
+  */
+ #if CFG_NUM_THREADS < 2
+-#define PGT_CACHE_SIZE	4
++#define PGT_CACHE_SIZE	8
+ #else
+-#define PGT_CACHE_SIZE	ROUNDUP(CFG_NUM_THREADS * 2, PGT_NUM_PGT_PER_PAGE)
++#define PGT_CACHE_SIZE	ROUNDUP(CFG_NUM_THREADS * 3, PGT_NUM_PGT_PER_PAGE)
+ #endif
+ 
+ SLIST_HEAD(pgt_cache, pgt);
+diff --git a/core/arch/arm/mm/core_mmu_lpae.c b/core/arch/arm/mm/core_mmu_lpae.c
+index 62cce13..51c7010 100644
+--- a/core/arch/arm/mm/core_mmu_lpae.c
++++ b/core/arch/arm/mm/core_mmu_lpae.c
+@@ -175,9 +175,9 @@
+ 
+ #ifndef MAX_XLAT_TABLES
+ #ifndef CFG_VIRTUALIZATION
+-#define MAX_XLAT_TABLES		5
++#define MAX_XLAT_TABLES		18
+ #else  /* CFG_VIRTUALIZATION*/
+-#define MAX_XLAT_TABLES		8
++#define MAX_XLAT_TABLES		18
+ #endif
+ #endif
+ 
+diff --git a/core/arch/arm/plat-vexpress/conf.mk b/core/arch/arm/plat-vexpress/conf.mk
+index a3cacc2..fb2d122 100644
+--- a/core/arch/arm/plat-vexpress/conf.mk
++++ b/core/arch/arm/plat-vexpress/conf.mk
+@@ -96,11 +96,11 @@ ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
+ CFG_TEE_CORE_NB_CORE = 4
+ # [0e00.0000 0e0f.ffff] is reserved to early boot
+ CFG_TZDRAM_START ?= 0x0e100000
+-CFG_TZDRAM_SIZE  ?= 0x00f00000
++CFG_TZDRAM_SIZE  ?= 0x1e00000
+ # SHM chosen arbitrary, in a way that it does not interfere
+ # with initial location of linux kernel, dtb and initrd.
+ CFG_SHMEM_START ?= 0x42000000
+-CFG_SHMEM_SIZE  ?= 0x00200000
++CFG_SHMEM_SIZE  ?= 0xA00000
+ # When Secure Data Path is enable, last MByte of TZDRAM is SDP test memory.
+ CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
+ $(call force,CFG_DT,y)
+diff --git a/core/arch/arm/plat-vexpress/platform_config.h b/core/arch/arm/plat-vexpress/platform_config.h
+index 8821a1f..0468386 100644
+--- a/core/arch/arm/plat-vexpress/platform_config.h
++++ b/core/arch/arm/plat-vexpress/platform_config.h
+@@ -88,7 +88,7 @@
+ #define DRAM1_SIZE		0x180000000UL
+ 
+ #define TZCDRAM_BASE		0xff000000
+-#define TZCDRAM_SIZE		0x01000000
++#define TZCDRAM_SIZE		0x02000000
+ 
+ #define GICC_OFFSET		0x0
+ #define GICD_OFFSET		0x3000000

--- a/src/arm/patches/qemu.patch
+++ b/src/arm/patches/qemu.patch
@@ -1,0 +1,13 @@
+diff --git a/hw/arm/virt.c b/hw/arm/virt.c
+index f69e7eb..474a880 100644
+--- a/hw/arm/virt.c
++++ b/hw/arm/virt.c
+@@ -146,7 +146,7 @@ static const MemMapEntry a15memmap[] = {
+     [VIRT_MMIO] =               { 0x0a000000, 0x00000200 },
+     /* ...repeating for a total of NUM_VIRTIO_TRANSPORTS, each of that size */
+     [VIRT_PLATFORM_BUS] =       { 0x0c000000, 0x02000000 },
+-    [VIRT_SECURE_MEM] =         { 0x0e000000, 0x01000000 },
++    [VIRT_SECURE_MEM] =         { 0x0e000000, 0x02000000 },
+     [VIRT_PCIE_MMIO] =          { 0x10000000, 0x2eff0000 },
+     [VIRT_PCIE_PIO] =           { 0x3eff0000, 0x00010000 },
+     [VIRT_PCIE_ECAM] =          { 0x3f000000, 0x01000000 },

--- a/src/arm/patches/users
+++ b/src/arm/patches/users
@@ -1,0 +1,1 @@
+runner -1 wheel -1 =runner - /bin/sh - Test User


### PR DESCRIPTION
These bits generate the tarball that's (yet to be) downloaded and extracted into the full Docker container images where the SDK builds for OP-TEE on ARM TrustZone.

The tarball contains the ARM TZ emulator and associated firmware and software to run the SDK's test suite during CI runs.

The script in this PR doesn't run automatically anywhere; it's just here for future reference in case the tarball needs to be rebuilt.

Associated with:
* [Add ARM64 CI Prerequisites to Full Container](https://github.com/openenclave/openenclave/pull/2526)
* [Enable Minimal ARM64 CI Tests](https://github.com/openenclave/openenclave/pull/2527)