### PR TITLE
Catch failures; Fix simulation mode tests

### DIFF
--- a/src/jenkins/common/Openenclave.groovy
+++ b/src/jenkins/common/Openenclave.groovy
@@ -142,27 +142,52 @@ def WinCompilePackageTest(String dirName, String buildType, String hasQuoteProvi
     cleanWs()
     checkout scm
     dir(dirName) {
-        bat """
-            vcvars64.bat x64 && \
-            cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${buildType} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${hasQuoteProvider} -DLVI_MITIGATION=${lviMitigation} -DLVI_MITIGATION_SKIP_TESTS=${lviMitigationSkipTests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCPACK_GENERATOR=NuGet -Wdev ${extra_cmake_args.join(' ')} && \
-            ninja.exe && \
-            ctest.exe -V -C ${buildType} --timeout ${timeoutSeconds} && \
-            cpack.exe -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY && \
-            cpack.exe && \
-            (if exist C:\\oe rmdir /s/q C:\\oe) && \
-            nuget.exe install open-enclave -Source %cd% -OutputDirectory C:\\oe -ExcludeVersion && \
-            set CMAKE_PREFIX_PATH=C:\\oe\\open-enclave\\openenclave\\lib\\openenclave\\cmake && \
-            cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples && \
-            setlocal enabledelayedexpansion && \
-            for /d %%i in (*) do (
-                cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples\\"%%i"
-                mkdir build
-                cd build
-                cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\\oe_prereqs -DLVI_MITIGATION=${lviMitigation} || exit /b %errorlevel%
-                ninja || exit /b %errorlevel%
-                ninja run || exit /b %errorlevel%
-            )
+        /*
+        In simulation mode, some samples should not be ran or should run simulation mode. 
+        For items that should be skipped, see items appended to SAMPLES_LIST under the IF statement with OE_SIMULATION in:
+        https://github.com/openenclave/openenclave/blob/master/samples/test-samples.cmake#L54
+        For items that should run in simulation mode, check sample Makefiles for target `simulate`
+        SIMULATION_SKIP is a "list" of samples to skip in simulation mode.
+        SIMULATION_TEST is a "list" of samples to run in simulation mode.
+        */
+        bat(
+            returnStdout: false,
+            returnStatus: false,
+            script: """
+                call vcvars64.bat x64
+                setlocal EnableDelayedExpansion
+                cmake.exe ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${buildType} -DBUILD_ENCLAVES=ON -DHAS_QUOTE_PROVIDER=${hasQuoteProvider} -DLVI_MITIGATION=${lviMitigation} -DLVI_MITIGATION_SKIP_TESTS=${lviMitigationSkipTests} -DNUGET_PACKAGE_PATH=C:/oe_prereqs -DCPACK_GENERATOR=NuGet -Wdev ${extra_cmake_args.join(' ')} || exit !ERRORLEVEL!
+                ninja.exe || exit !ERRORLEVEL!
+                ctest.exe -V -C ${buildType} --timeout ${timeoutSeconds} || exit !ERRORLEVEL!
+                cpack.exe -D CPACK_NUGET_COMPONENT_INSTALL=ON -DCPACK_COMPONENTS_ALL=OEHOSTVERIFY || exit !ERRORLEVEL!
+                cpack.exe || exit !ERRORLEVEL!
+                if exist C:\\oe rmdir /s/q C:\\oe
+                nuget.exe install open-enclave -Source %cd% -OutputDirectory C:\\oe -ExcludeVersion
+                set CMAKE_PREFIX_PATH=C:\\oe\\open-enclave\\openenclave\\lib\\openenclave\\cmake
+                set SIMULATION_SKIP="\\attested_tls\\attestation\\"
+                set SIMULATION_TEST="\\debugmalloc\\helloworld\\switchless\\log_callback\\file-encryptor\\pluggable_allocator\\"
+                cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples
+                for /d %%i in (*) do (
+                    set BUILD=1
+                    if ${OE_SIMULATION} equ 1 if "!SIMULATION_SKIP:%%~nxi=!" neq "%SIMULATION_SKIP%" set BUILD=
+                    if !BUILD! equ 1 (
+                        cd C:\\oe\\open-enclave\\openenclave\\share\\openenclave\\samples\\"%%i"
+                        mkdir build
+                        cd build
+                        cmake .. -G Ninja -DNUGET_PACKAGE_PATH=C:\\oe_prereqs -DLVI_MITIGATION=${lviMitigation} || exit !ERRORLEVEL!
+                        ninja || exit !ERRORLEVEL!
+                        if ${OE_SIMULATION} equ 1 if "!SIMULATION_TEST:%%~nxi=!" neq "%SIMULATION_TEST%" (
+                            echo "Running %%i with --simulation flag" 
+                            ninja simulate || exit !ERRORLEVEL!
+                        ) else (
+                            ninja run || exit !ERRORLEVEL!
+                        )
+                    ) else (
+                        echo "Skipping %%i as we are in simulation mode."
+                    )
+                )
             """
+        )
     }
 }
 


### PR DESCRIPTION
This will do the following:

1) Failures when building with the bat script will now be caught by Jenkins as failures
2) In simulation mode, there are samples that should be skipped. See items appended to SAMPLES_LIST under the IF statement with OE_SIMULATION in https://github.com/openenclave/openenclave/blob/master/samples/test-samples.cmake#L54
3) In simulation mode, samples should use target `simulate` instead of `run` when available.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>